### PR TITLE
Added grouping to the Content module.

### DIFF
--- a/app/modules/content/templates/index.tpl
+++ b/app/modules/content/templates/index.tpl
@@ -1,5 +1,11 @@
 {include file="findInclude:common/templates/header.tpl"}
 
+{if isset($description) && strlen($description)}
+  <p class="{block name='headingClass'}nonfocal smallprint{/block}">
+    {$description|escape}
+  </p>
+{/if}
+
 {include file="findInclude:common/templates/navlist.tpl" navlistItems=$contentPages}
     
 {include file="findInclude:common/templates/footer.tpl"}


### PR DESCRIPTION
USAGE:
To add a group, create a file called 'feedgroups.ini' in
$configModule. Add entries by creating a unique section title,
and adding a TITLE configuration option for that section. A
DESCRIPTION option may be optionally added as well. If there is
no description set, group descriptions will be taken from the
mandatory module description. If you would like no descriptions
at all, set the module description to be empty.

After creating a group entry in 'feedgroups.ini', create a file
titled 'feeds-[groupname].ini'. In this file, add content entries
as you normally would.

Finally, edit 'feeds.ini' to contain group and/or content entries.
Group entries should consist of a unique section identifier, an
optional title (the title specified in 'feedgroups.ini' will be
used if no title is set in 'feeds.ini') and a GROUP configuration
option with the same identifier used in 'feedgroups.ini'.

Content entries in 'feeds.ini' are entered as usual. This should
ensure that backwards compatibility is maintained, and sites using
the old version of the Content module will continue to function as
expected.

OTHER FEATURES:
If only a single piece of content is entered in 'feeds.ini',
visiting the module url will result in that content being
displayed. If there is only one group, that group will be
displayed. If there is only one entry in a group, that entry will
be shown instead of the group listing.
