### PR TITLE
Fixed recurrence id checking.

### DIFF
--- a/lib/Calendar/ICalendar.php
+++ b/lib/Calendar/ICalendar.php
@@ -501,15 +501,18 @@ class ICalEvent extends ICalObject implements KurogoObject {
      * Answer an ICalEvent that is an exception to the normal recurrence pattern
      * if one exists for the start-time given. FALSE if none match.
      * @param int $time
-     * @return mixed ICalEvent or null
+     * @return mixed ICalEvent or false
      */
     public function getRecurrenceException($time) {
         $recurrence_id = strftime("%Y%m%dT%H%M%S",$time);
         foreach ($this->recurrence_exceptions as $exception) {
-            if ($exception->get_recurid() == $recurrence_id)
+            // Some ical feeds only have the %Y%m%d portion for DTSTART/DTEND (Google Calendar feeds),
+            // so first check for an exact match, then try adding a T000000 time and check again.
+            if (($exception->get_recurid() == $recurrence_id) || ($exception->get_recurid().'T000000' == $recurrence_id)){
                 return $exception;
+            }
         }
-        return null;
+        return false;
     }
 
     public function outputICS() {

--- a/lib/Calendar/ICalendar.php
+++ b/lib/Calendar/ICalendar.php
@@ -499,9 +499,9 @@ class ICalEvent extends ICalObject implements KurogoObject {
 
     /**
      * Answer an ICalEvent that is an exception to the normal recurrence pattern
-     * if one exists for the start-time given. FALSE if none match.
+     * if one exists for the start-time given. null if none match.
      * @param int $time
-     * @return mixed ICalEvent or false
+     * @return mixed ICalEvent or null
      */
     public function getRecurrenceException($time) {
         $recurrence_id = strftime("%Y%m%dT%H%M%S",$time);
@@ -512,7 +512,7 @@ class ICalEvent extends ICalObject implements KurogoObject {
                 return $exception;
             }
         }
-        return false;
+        return null;
     }
 
     public function outputICS() {


### PR DESCRIPTION
Some ical feeds only have the %Y%m%d portion for DTSTART/DTEND (Google Calendar feeds), so first check for an exact match, then try adding a 'T000000' time and check again.
