### PR TITLE
If there is garbage at the start of an ICal feed, throw an Exception rather than a Fatal Error.

### DIFF
--- a/lib/Calendar/ICSDataParser.php
+++ b/lib/Calendar/ICSDataParser.php
@@ -145,6 +145,9 @@ class ICSDataParser extends DataParser
                 break;
             default:
                 try {
+                    if (empty($nesting))
+                        throw new ICalendarException('Something other than BEGIN at the start of the calendar: '.$line);
+                    
                     end($nesting)->set_attribute($contentname, $value, $params);
                 } catch (Exception $e) {
                     if ($this->haltOnParseErrors) {


### PR DESCRIPTION
Trying to parse an ICal feed with garbage at the beginning of the feed
was causing fatal errors due to end($nesting) returning FALSE rather than an
object. This change allows parsing to throw an Exception that might be
handled more gracefully.

This change is based of an old point in the master branch (where we last merged from), but should merge cleanly into the current master.
