### PR TITLE
Log out of the CAS server when logging out of Kurogo.

### DIFF
--- a/lib/Authentication/CASAuthentication.php
+++ b/lib/Authentication/CASAuthentication.php
@@ -186,6 +186,21 @@ class CASAuthentication
     {
         return array('LINK', 'NONE');
     }
+
+    /***
+     * Resets the authority and returns it to a fresh state.
+     * Called by the logout method to clean up any authority specific data (caches etc). Not all authorities will need this
+     * @param bool $hard if true a hard reset is done
+     */
+    protected function reset($hard=false)
+    {
+        // Log out from the CAS server
+        if (phpCAS::isAuthenticated()) {
+            $service = "http".(IS_SECURE ? 's' : '')."://".SERVER_HOST.$_SERVER['REQUEST_URI'];
+            phpCAS::logoutWithRedirectServiceAndUrl($service, $service);
+        }
+        return true;
+    }
 }
 
 /**


### PR DESCRIPTION
This patch works because phpCAS itself calls

```
session_unset();
session_destroy();
```

in its `logout()` function before redirecting the user to the CAS server to log out there. That said, the following code in Session::logout() doesn't get called due to the redirect and exit() in phpCAS:

```
unset($this->users[$authority->getAuthorityIndex()]);
$this->setSessionVars();
$this->setLoginCookie();
session_regenerate_id(true);
```

Ideally, the phpCAS::logout() function should be called via a hook that runs after the Kurogo Session::logout() code has finished cleaning up the session(). Without such a hook available however, this patch is probably the best option. 
