### PR TITLE
Video module iphone specific template for youtube video

### DIFF
--- a/app/modules/video/templates/detail-youtube-compliant-iphone.tpl
+++ b/app/modules/video/templates/detail-youtube-compliant-iphone.tpl
@@ -1,0 +1,6 @@
+{extends file="findExtends:modules/video/templates/detail-youtube.tpl"}
+
+{block name="videoPlayer"}
+<iframe class="youtube-player" type="text/html" width="298" height="200" scrolling="no" src="http://www.youtube.com/embed/{$videoid}?html5=1&controls=0&rel=0&hd=0&title=" frameborder="0">
+</iframe>
+{/block}


### PR DESCRIPTION
We weren't able to play youtube video on iphone from the videos module. We created this template in our theme override, changing the iframe src, to get it to work. Adding ?html5=1 and removing modest branding did the trick for us.

Just thought we'd pass it along in case it's helpful.

Cheers
