### PR TITLE
Minor change to date formatting in VideoWebModule

### DIFF
--- a/app/modules/video/VideoWebModule.php
+++ b/app/modules/video/VideoWebModule.php
@@ -266,7 +266,7 @@ class VideoWebModule extends WebModule
                         $this->assign('videoStillImage',  $video->getStillFrameImage());
                         $this->assign('videoDescription', $video->getDescription());
                         $this->assign('videoAuthor'     , $video->getAuthor());
-                        $this->assign('videoDate'       , $video->getPublished()->format('M n, Y'));
+                        $this->assign('videoDate'       , $video->getPublished()->format('M j, Y'));
                         
                         $body = $video->getDescription() . "\n\n" . $video->getURL();
     


### PR DESCRIPTION
Changed date format in VideoWebModule. Date format 'M n, Y' lists the value of the month twice since 'n' is the numeric representation of the month without leading zeroes. Changed this value to 'M j, Y' which will print the numeric representation of the day without leading zeroes instead.
