### PR TITLE
Retriever Class Names in Video Admin config Updated

### DIFF
--- a/app/modules/video/config/admin-module.json
+++ b/app/modules/video/config/admin-module.json
@@ -19,8 +19,8 @@
             "TITLE":{"labelKey":"VIDEO_ADMIN_FEEDS_TITLE_TITLE","descriptionKey":"VIDEO_ADMIN_FEEDS_TITLE_DESCRIPTION", "type":"text"},
             "RETRIEVER_CLASS":{"labelKey":"VIDEO_ADMIN_FEEDS_CONTROLLER_TITLE", "descriptionKey":"VIDEO_ADMIN_FEEDS_CONTROLLER_DESCRIPTION", "type":"select","optionsMethod":["VideoDataModel","getVideoDataRetrievers"],"optionsFirst":"-- Choose a video provider --"},
             "AUTHOR":{"labelKey":"VIDEO_ADMIN_FEEDS_AUTHOR_TITLE","descriptionKey":"VIDEO_ADMIN_FEEDS_AUTHOR_DESCRIPTION","type":"text","omitBlankValue":true},
-            "CHANNEL":{"labelKey":"VIDEO_ADMIN_FEEDS_CHANNEL_TITLE","descriptionKey":"VIDEO_ADMIN_FEEDS_CHANNEL_DESCRIPTION","type":"text","omitBlankValue":true,"showIf":["RETRIEVER_CLASS",["VimeoVideoRetriever"]]},
-            "PLAYLIST":{"labelKey":"VIDEO_ADMIN_FEEDS_PLAYLIST_TITLE","descriptionKey":"VIDEO_ADMIN_FEEDS_PLAYLIST_DESCRIPTION","type":"text","omitBlankValue":true,"showIf":["RETRIEVER_CLASS",["YouTubeVideoRetriever"]]},
+            "CHANNEL":{"labelKey":"VIDEO_ADMIN_FEEDS_CHANNEL_TITLE","descriptionKey":"VIDEO_ADMIN_FEEDS_CHANNEL_DESCRIPTION","type":"text","omitBlankValue":true,"showIf":["RETRIEVER_CLASS",["VimeoRetriever"]]},
+            "PLAYLIST":{"labelKey":"VIDEO_ADMIN_FEEDS_PLAYLIST_TITLE","descriptionKey":"VIDEO_ADMIN_FEEDS_PLAYLIST_DESCRIPTION","type":"text","omitBlankValue":true,"showIf":["RETRIEVER_CLASS",["YouTubeRetriever"]]},
             "TAG":{"labelKey":"VIDEO_ADMIN_FEEDS_TAG_TITLE","descriptionKey":"VIDEO_ADMIN_FEEDS_TAG_DESCRIPTION","type":"text","omitBlankValue":true}
         },
         "sectionindex":"string",


### PR DESCRIPTION
Updated retriever class names to actual retriever class names. Playlist option now shows up for YouTube and Channel option for Vimeo. This is a very small change, but one that affects the functionality of configuring the video feeds.
