### PR TITLE
Added Pluralizer class for use throughout the framework.

### DIFF
--- a/lib/Pluralizer.php
+++ b/lib/Pluralizer.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+  * @package Core
+  */
+
+class Pluralizer {
+
+    public static function pluralize($count, $singular, $plural = null){
+        return (abs($count) == 1) ? $singular : ( isset($plural) ? $plural : Inflector::pluralize($singular));
+    }
+}
+
+class Inflector {
+
+    /**
+     * Plural inflector rules
+     */
+    protected static $_plural = array(
+        'rules' => array(
+            '/(s)tatus$/i' => '\1\2tatuses',
+            '/(quiz)$/i' => '\1zes',
+            '/^(ox)$/i' => '\1\2en',
+            '/([m|l])ouse$/i' => '\1ice',
+            '/(matr|vert|ind)(ix|ex)$/i' => '\1ices',
+            '/(x|ch|ss|sh)$/i' => '\1es',
+            '/([^aeiouy]|qu)y$/i' => '\1ies',
+            '/(hive)$/i' => '\1s',
+            '/(?:([^f])fe|([lr])f)$/i' => '\1\2ves',
+            '/sis$/i' => 'ses',
+            '/([ti])um$/i' => '\1a',
+            '/(p)erson$/i' => '\1eople',
+            '/(m)an$/i' => '\1en',
+            '/(c)hild$/i' => '\1hildren',
+            '/(buffal|tomat)o$/i' => '\1\2oes',
+            '/(alumn|bacill|cact|foc|fung|nucle|radi|stimul|syllab|termin|vir)us$/i' => '\1i',
+            '/us$/i' => 'uses',
+            '/(alias)$/i' => '\1es',
+            '/(ax|cris|test)is$/i' => '\1es',
+            '/s$/' => 's',
+            '/^$/' => '',
+            '/$/' => 's',
+        ),
+        'uninflected' => array(
+            '.*[nrlm]ese', '.*deer', '.*fish', '.*measles', '.*ois', '.*pox', '.*sheep', 'people'
+        ),
+        'irregular' => array(
+            'atlas' => 'atlases',
+            'beef' => 'beefs',
+            'brother' => 'brothers',
+            'cafe' => 'cafes',
+            'child' => 'children',
+            'corpus' => 'corpuses',
+            'cow' => 'cows',
+            'ganglion' => 'ganglions',
+            'genie' => 'genies',
+            'genus' => 'genera',
+            'graffito' => 'graffiti',
+            'hoof' => 'hoofs',
+            'loaf' => 'loaves',
+            'man' => 'men',
+            'money' => 'monies',
+            'mongoose' => 'mongooses',
+            'move' => 'moves',
+            'mythos' => 'mythoi',
+            'niche' => 'niches',
+            'numen' => 'numina',
+            'occiput' => 'occiputs',
+            'octopus' => 'octopuses',
+            'opus' => 'opuses',
+            'ox' => 'oxen',
+            'penis' => 'penises',
+            'person' => 'people',
+            'sex' => 'sexes',
+            'soliloquy' => 'soliloquies',
+            'testis' => 'testes',
+            'trilby' => 'trilbys',
+            'turf' => 'turfs'
+        )
+    );
+
+    /**
+     * Words that should not be inflected
+     */
+    protected static $_uninflected = array(
+        'Amoyese', 'bison', 'Borghese', 'bream', 'breeches', 'britches', 'buffalo', 'cantus',
+        'carp', 'chassis', 'clippers', 'cod', 'coitus', 'Congoese', 'contretemps', 'corps',
+        'debris', 'diabetes', 'djinn', 'eland', 'elk', 'equipment', 'Faroese', 'flounder',
+        'Foochowese', 'gallows', 'Genevese', 'Genoese', 'Gilbertese', 'graffiti',
+        'headquarters', 'herpes', 'hijinks', 'Hottentotese', 'information', 'innings',
+        'jackanapes', 'Kiplingese', 'Kongoese', 'Lucchese', 'mackerel', 'Maltese', '.*?media',
+        'mews', 'moose', 'mumps', 'Nankingese', 'news', 'nexus', 'Niasese',
+        'Pekingese', 'Piedmontese', 'pincers', 'Pistoiese', 'pliers', 'Portuguese',
+        'proceedings', 'rabies', 'rice', 'rhinoceros', 'salmon', 'Sarawakese', 'scissors',
+        'sea[- ]bass', 'series', 'Shavese', 'shears', 'siemens', 'species', 'swine', 'testes',
+        'trousers', 'trout', 'tuna', 'Vermontese', 'Wenchowese', 'whiting', 'wildebeest',
+        'Yengeese'
+    );
+
+
+    public static function pluralize($word){
+        if(empty($word)){
+            throw new KurogoException("Singular value must not be empty");
+            return;
+        }
+
+        self::$_plural['cacheIrregular'] = '(?:' . implode('|', array_keys(self::$_plural['irregular'])) . ')';
+        self::$_plural['cacheUninflected'] = '(?:' . implode('|', self::$_plural['uninflected']) . ')';
+
+        if (preg_match('/(.*)\\b(' . self::$_plural['cacheIrregular'] . ')$/i', $word, $regs)) {
+            return $regs[1] . substr($word, 0, 1) . substr(self::$_plural['irregular'][strtolower($regs[2])], 1);
+        }
+
+        if (preg_match('/^(' . self::$_plural['cacheUninflected'] . ')$/i', $word, $regs)) {
+            return $word;
+        }
+
+        foreach (self::$_plural['rules'] as $rule => $replacement) {
+            if (preg_match($rule, $word)) {
+                return preg_replace($rule, $replacement, $word);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Pluralizer::pluralize($count, $singular, $plural = null)

Returns the plural form of $singular if $count is not -1 or 1. Uses
the given plural form if $plural is not null.
