### PR TITLE
CASAuthentication - Added support for database storage of proxy-granting-tickets.

### DIFF
--- a/doc/mw/CASAuthentication.rst
+++ b/doc/mw/CASAuthentication.rst
@@ -44,6 +44,10 @@ to Kurogo to display full names and support group-based :doc:`authorization`.
 * *ATTRA_FULL_NAME* - Attribute name for the user's full name, e.g. ``"displayname"``.
 * *ATTRA_MEMBER_OF* - Attribute name for the user's groups, e.g. ``"memberof"``.
 
+Other optional parameters:
+
+* *CAS_DEBUG_LOG* - The path of a log file in which phpCAS should log its activity. Only set this parameter for testing/debugging as the log files grow very rapidly. E.g. ``"/var/log/phpcas.log"``
+
 .. code-block:: ini
 
     [cas]
@@ -55,6 +59,7 @@ to Kurogo to display full names and support group-based :doc:`authorization`.
     CAS_PORT                = 443
     CAS_PATH                = "/cas/"
     CAS_CA_CERT             = ""
+    CAS_DEBUG_LOG           = ""
     ATTRA_EMAIL             = "EMail"
     ATTRA_FIRST_NAME        = "FirstName"
     ATTRA_LAST_NAME         = "LastName"

--- a/lib/Authentication/CASAuthentication.php
+++ b/lib/Authentication/CASAuthentication.php
@@ -96,8 +96,13 @@ class CASAuthentication
         } else {
             phpCAS::proxy($args['CAS_PROTOCOL'], $args['CAS_HOST'], intval($args['CAS_PORT']), $args['CAS_PATH'], false);
             
-            if (!empty($args['CAS_PROXY_TICKET_PATH']))
-                phpCAS::setPGTStorageFile('', $args['CAS_PROXY_TICKET_PATH']);
+            if (!empty($args['CAS_PROXY_TICKET_PATH'])) {
+                if (version_compare(PHPCAS_VERSION, '1.3', '>=')) {
+                    phpCAS::setPGTStorageFile($args['CAS_PROXY_TICKET_PATH']);
+                } else {
+                    phpCAS::setPGTStorageFile('', $args['CAS_PROXY_TICKET_PATH']);
+                }
+            }
             
             if (!empty($args['CAS_PROXY_FIXED_CALLBACK_URL']))
                 phpCAS::setFixedCallbackURL($args['CAS_PROXY_FIXED_CALLBACK_URL']);

--- a/lib/Authentication/CASAuthentication.php
+++ b/lib/Authentication/CASAuthentication.php
@@ -79,6 +79,9 @@ class CASAuthentication
         else
             require_once($args['CAS_PHPCAS_PATH'].'/CAS.php');
     
+        if (!empty($args['CAS_DEBUG_LOG']))
+            phpCAS::setDebug($args['CAS_DEBUG_LOG']);
+        
         if (empty($args['CAS_PROTOCOL']))
             throw new KurogoConfigurationException('CAS_PROTOCOL value not set for ' . $this->AuthorityTitle);
     

--- a/lib/Authentication/CASAuthentication.php
+++ b/lib/Authentication/CASAuthentication.php
@@ -99,8 +99,24 @@ class CASAuthentication
         } else {
             phpCAS::proxy($args['CAS_PROTOCOL'], $args['CAS_HOST'], intval($args['CAS_PORT']), $args['CAS_PATH'], false);
             
+            if (!empty($args['CAS_PROXY_TICKET_PATH']) && !empty($args['CAS_PROXY_TICKET_DB_DSN']))
+            	throw new KurogoConfigurationException('Only one of CAS_PROXY_TICKET_PATH or CAS_PROXY_TICKET_DB_DSN may be set for ' . $this->AuthorityTitle);
+            
             if (!empty($args['CAS_PROXY_TICKET_PATH']))
                 phpCAS::setPGTStorageFile('', $args['CAS_PROXY_TICKET_PATH']);
+            
+            if (!empty($args['CAS_PROXY_TICKET_DB_DSN'])) {
+                $user = $pass = $table = $driver_opts = '';
+                if (!empty($args['CAS_PROXY_TICKET_DB_USER']))
+                    $user = $args['CAS_PROXY_TICKET_DB_USER'];
+                if (!empty($args['CAS_PROXY_TICKET_DB_PASS']))
+                    $pass = $args['CAS_PROXY_TICKET_DB_PASS'];
+                if (!empty($args['CAS_PROXY_TICKET_DB_TABLE']))
+                    $table = $args['CAS_PROXY_TICKET_DB_TABLE'];
+                if (!empty($args['CAS_PROXY_TICKET_DB_DRIVER_OPTS']))
+                    $driver_opts = $args['CAS_PROXY_TICKET_DB_DRIVER_OPTS'];
+                phpCAS::setPGTStorageDb($args['CAS_PROXY_TICKET_DB_DSN'], $user, $pass, $table, $driver_opts);
+            }
             
             if (!empty($args['CAS_PROXY_FIXED_CALLBACK_URL']))
                 phpCAS::setFixedCallbackURL($args['CAS_PROXY_FIXED_CALLBACK_URL']);


### PR DESCRIPTION
Storing proxy-granting-tickets (PGTs) in a shared database facilitates serving Kurogo from a cluster of web-hosts. Since the end-user and the CAS server may each make requests to different hosts in the cluster, the PGTs provided by the CAS server must be placed in a shared location available to all other hosts.

This facility is provided by the underlying phpCAS library. This patch simply allows its configuration via the Kurogo ini files.

Also included in this pull request is the ability to configure phpCAS to write its debug log.
