### PR TITLE
Allow setting the ACTIVE_SITE via the environment.

### DIFF
--- a/doc/mw/multisite.rst
+++ b/doc/mw/multisite.rst
@@ -36,3 +36,42 @@ To setup Multisite, you must first enable it in the config/kurogo.ini file.
     ACTIVE_SITES[] = "es"
 
 This would enable only the *en* and *es* sites on this server.
+
+============================================
+Setting the active-site from the environment
+============================================
+
+There are some cases where there is a need to host multiple Kurogo sites from the same 
+webserver, but where one cannot use MultiSite mode due to its dependency on subpaths. 
+An example is serving each Kurogo site under a different host-name or domain name, 
+e.g. students.example.edu and faculty.example.edu.
+
+To accomplish this switching, Kurogo supports the specification of the ``ACTIVE_SITE`` 
+parameter via an environmental variable set by your webserver. Kurogo will only look for the ``ACTIVE_SITE`` in the environment when *not* in MultiSite mode and when the ``ACTIVE_SITE`` parameter has no value.
+
+Example ``kurogo.ini``:
+
+.. code-block:: ini
+
+	[kurogo]
+	MULTI_SITE = 0
+	ACTIVE_SITE = ""
+
+The ``ACTIVE_SITE`` environmental parameter can be set in a number of ways, but one of
+the easiest is in your Apache configuration:
+
+::
+	
+	<VirtualHost *:80>
+		ServerName students.example.edu
+		DocumentRoot /var/www/kurogo/www/
+		
+		SetEnv ACTIVE_SITE Students
+	</VirtualHost>
+
+	<VirtualHost *:80>
+		ServerName faculty.example.edu
+		DocumentRoot /var/www/kurogo/www/
+		
+		SetEnv ACTIVE_SITE Faculty
+	</VirtualHost>

--- a/lib/Kurogo.php
+++ b/lib/Kurogo.php
@@ -734,6 +734,21 @@ class Kurogo
             define('SITE_NAME', $site);
 
         } else {
+            // If there is no active site configured and there is one set in the environment
+            // (such as set by a VirtualHost SetEnv entry), then set the active site to the one
+            // defined in the environment.
+            try {
+                $activeSite = $siteConfig->getVar('ACTIVE_SITE', 'kurogo');
+                if (empty($activeSite)) {
+                    throw new KurogoKeyNotFoundException('ACTIVE_SITE is empty');
+                }
+            } catch (KurogoKeyNotFoundException $e) {
+                $activeSite = getenv('ACTIVE_SITE');
+                if (!empty($activeSite)) {
+                    $siteConfig->setVar('kurogo', 'ACTIVE_SITE', $activeSite, $changed);
+                }
+            }
+            
         	$site = '';
             if (PHP_SAPI == 'cli') {
 


### PR DESCRIPTION
This patch allows Kurogo to serve multiple sites from the same code directory
where the active-site selection is configured by something beyond the limited subpath
structure of MultiSite mode.

One example enabled by this patch is to serve different Kurogo sites for each
VirtualHost on the machine:

```
<VirtualHost *:80>
    ServerName students.example.edu
    DocumentRoot /var/www/kurogo/www/

    SetEnv ACTIVE_SITE Students
</VirtualHost>

<VirtualHost *:80>
    ServerName faculty.example.edu
    DocumentRoot /var/www/kurogo/www/

    SetEnv ACTIVE_SITE Faculty
</VirtualHost>
```

This patch does not interfere with normal single-site operation or with MultiSite
mode. See the additions to doc/mw/multisite.rst in this patch for more detailed
configuration instructions.
