### PR TITLE
CASAuthentication - Fix for an argument change in phpCAS 1.3+

### DIFF
--- a/lib/Authentication/CASAuthentication.php
+++ b/lib/Authentication/CASAuthentication.php
@@ -96,8 +96,13 @@ class CASAuthentication
         } else {
             phpCAS::proxy($args['CAS_PROTOCOL'], $args['CAS_HOST'], intval($args['CAS_PORT']), $args['CAS_PATH'], false);
             
-            if (!empty($args['CAS_PROXY_TICKET_PATH']))
-                phpCAS::setPGTStorageFile('', $args['CAS_PROXY_TICKET_PATH']);
+            if (!empty($args['CAS_PROXY_TICKET_PATH'])) {
+                if (version_compare(PHPCAS_VERSION, '1.3', '>=')) {
+                    phpCAS::setPGTStorageFile($args['CAS_PROXY_TICKET_PATH']);
+                } else {
+                    phpCAS::setPGTStorageFile('', $args['CAS_PROXY_TICKET_PATH']);
+                }
+            }
             
             if (!empty($args['CAS_PROXY_FIXED_CALLBACK_URL']))
                 phpCAS::setFixedCallbackURL($args['CAS_PROXY_FIXED_CALLBACK_URL']);


### PR DESCRIPTION
CASAuthentication - Fix for a change in the arguments for phpCAS::setPGTStorageFile()

phpCAS 1.3+ no longer takes a 'format' argument for phpCAS::setPGTStorageFile(). This change allows proxy-ticket storage to work with all versions of phpCAS.

This is a bug-fix that is independent of #64 "CASAuthentication - Added support for database storage of proxy-granting-tickets", but both modify the same block of code and cause merge conflicts with each other. To allow for easy addition of both, I've already merged this fix onto the branch for #64. If that feature is not desired, merge this pull request alone. 
