### PR TITLE
FacebookDataRetriever no longer works (it seems) - a fix!

### DIFF
--- a/app/modules/social/lib/FacebookDataRetriever.php
+++ b/app/modules/social/lib/FacebookDataRetriever.php
@@ -132,8 +132,15 @@ class FacebookDataParser extends DataParser
             $post->setBody($entry['message']);
         }
         
-        if (isset($entry['likes'])) {
-            $post->setLikeCount($entry['likes']['count']);
+        if (isset($entry['likes'])) {   
+            if(empty($entry['likes']['count'])) {
+                $amount_likes = count($entry['likes']['data']);
+            }
+            else {
+                $amount_likes = $entry['likes']['count'];
+            }
+            
+            $post->setLikeCount($amount_likes);
         }
         
         switch ($entry['type'])


### PR DESCRIPTION
It seems the FacebookDataRetriever is broken. For me and several other users, as reported on the community boards, it errors out saying that there is an undefined index 'count' on line 136.

Looking at the FB JSON response, it seems that the 'count' index is indeed missing from the 'likes' array. This is a fix for the issue, which first tries to use the 'count' index, but does a quick calculation to calculate the likes if it isn't given by the JSON.
